### PR TITLE
Fix alert audio volume behavior on phone

### DIFF
--- a/app/src/main/java/com/qualcomm/alvion/RootActivity.kt
+++ b/app/src/main/java/com/qualcomm/alvion/RootActivity.kt
@@ -1,5 +1,6 @@
 package com.qualcomm.alvion
 
+import android.media.AudioManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -22,6 +23,10 @@ import com.qualcomm.alvion.feature.shell.AppShell
 class RootActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        // Link hardware volume buttons to the Media stream
+        volumeControlStream = AudioManager.STREAM_MUSIC
+
         enableEdgeToEdge()
         setContent {
             val context = LocalContext.current

--- a/app/src/main/java/com/qualcomm/alvion/feature/home/util/AlertAudioManager.kt
+++ b/app/src/main/java/com/qualcomm/alvion/feature/home/util/AlertAudioManager.kt
@@ -27,9 +27,8 @@ class AlertAudioManager(
             .setAudioAttributes(
                 AudioAttributes
                     .Builder()
-                    .setUsage(AudioAttributes.USAGE_ALARM)
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
                     .build(),
             ).build()
 


### PR DESCRIPTION
## Description
Updated audio handling so alert sounds respect the devices volume instead of playing at a fixed enforced level. 

Fixes # (85)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
- [x] Manual test on physical device (Model: )
- [x] Manual test on Emulator (API Level: )

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable)
Add screenshots or screen recordings to help explain your changes.
